### PR TITLE
Expose Error

### DIFF
--- a/examples/packet_handler.rs
+++ b/examples/packet_handler.rs
@@ -1,0 +1,35 @@
+extern crate netfilter_queue as nfq;
+
+use std::ptr::null;
+use nfq::handle::{Handle, ProtocolFamily};
+use nfq::queue::{CopyMode, Verdict, PacketHandler, QueueHandle};
+use nfq::message::Message;
+use nfq::error::Error;
+
+fn main() {
+    let mut handle = Handle::new().ok().unwrap();
+    handle.bind(ProtocolFamily::INET).ok().unwrap();
+
+    let mut queue = handle.queue(0, Decider).ok().unwrap();
+    let _ = queue.set_mode(CopyMode::Metadata).unwrap();
+
+    println!("Listening for packets...");
+    handle.start(4096);
+
+    println!("...finished.");
+}
+
+struct Decider;
+
+impl PacketHandler for Decider {
+    #[allow(non_snake_case)]
+    fn handle(&mut self, hq: *mut QueueHandle, message: Result<&Message, &Error>) -> i32 {
+        match message {
+            Ok(m) => {
+                let _ = Verdict::set_verdict(hq, m.header.id(), Verdict::Accept, 0, null());
+            },
+            Err(_) => ()
+        }
+        0
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use libc::c_int;
 use std::error::Error as Base;
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@ extern crate lazy_static;
 
 mod ffi;
 
-mod error;
 mod util;
 mod lock;
 
+pub mod error;
 pub mod handle;
 pub mod queue;
 pub mod message;


### PR DESCRIPTION
A PacketHandler could not have been impl'ed before, as Error was not exposed.
